### PR TITLE
poc: update the plan command to generate state for the resources instances that does not have state for the sam cli integration mode

### DIFF
--- a/internal/terraform/node_resource_abstract.go
+++ b/internal/terraform/node_resource_abstract.go
@@ -413,6 +413,10 @@ func (n *NodeAbstractResource) readResourceInstanceState(ctx EvalContext, addr a
 		if !samCliIntegration {
 			return nil, nil
 		}
+		
+		// For the purpose of POC, I have hard-coded the Provider type, resources, and attributes that will be generated.
+		// However, in the actual implementation, Terraform will rely on a new parameter to determine which resources and 
+		// attributes should be generated, as well as the value pattern to be used in generating their values.
 		provider := n.Provider()
 		if provider.Type != "aws" || provider.Namespace != "hashicorp" {
 			return nil, nil

--- a/internal/terraform/node_resource_abstract_instance.go
+++ b/internal/terraform/node_resource_abstract_instance.go
@@ -892,7 +892,8 @@ func (n *NodeAbstractResourceInstance) plan(
 	// changes in processIgnoreChanges -- so now we'll filter that list to
 	// include only where changes are detected.
 	reqRep := cty.NewPathSet()
-	if len(resp.RequiresReplace) > 0 {
+	samCliIntegration := true
+	if len(resp.RequiresReplace) > 0 && !samCliIntegration {
 		for _, path := range resp.RequiresReplace {
 			if priorVal.IsNull() {
 				// If prior is null then we don't expect any RequiresReplace at all,


### PR DESCRIPTION
This a draft PR to show the changes we did as a POC for the suggested changes to be done in terraform plan command to resolve the limitations AWS SAM CLI tool faces during the integration with terraform.

More details shared in a separate design document.